### PR TITLE
Add some minimal support for mesh loading

### DIFF
--- a/qtcsg/CMakeLists.txt
+++ b/qtcsg/CMakeLists.txt
@@ -2,6 +2,8 @@ add_library(
     QtCSG
     qtcsg.cpp
     qtcsg.h
+    qtcsgio.cpp
+    qtcsgio.h
     qtcsgmath.cpp
     qtcsgmath.h
 )

--- a/qtcsg/qtcsg.cpp
+++ b/qtcsg/qtcsg.cpp
@@ -176,7 +176,7 @@ Geometry Geometry::inversed() const
     inverse.reserve(m_polygons.size());
     std::copy(m_polygons.begin(), m_polygons.end(), std::back_inserter(inverse));
     std::for_each(inverse.begin(), inverse.end(), &flip<Polygon>);
-    return {std::move(inverse)};
+    return Geometry{std::move(inverse)};
 }
 
 Geometry Geometry::transformed(const QMatrix4x4 &matrix) const
@@ -191,7 +191,7 @@ Geometry Geometry::transformed(const QMatrix4x4 &matrix) const
     std::transform(m_polygons.cbegin(), m_polygons.cend(),
                    std::back_inserter(transformed), applyMatrix);
 
-    return {std::move(transformed)};
+    return Geometry{std::move(transformed)};
 }
 
 Geometry cube(QVector3D center, QVector3D size)
@@ -307,7 +307,7 @@ Geometry merge(Geometry lhs, Geometry rhs, int limit)
 
     const auto error = a.build(b.allPolygons(), limit);
 
-    return {a.allPolygons(), error};
+    return Geometry{a.allPolygons(), error};
 }
 
 Geometry subtract(Geometry lhs, Geometry rhs, int limit)
@@ -326,7 +326,7 @@ Geometry subtract(Geometry lhs, Geometry rhs, int limit)
 
     a.invert();
 
-    return {a.allPolygons(), error};
+    return Geometry{a.allPolygons(), error};
 }
 
 Geometry intersect(Geometry lhs, Geometry rhs, int limit)
@@ -344,7 +344,7 @@ Geometry intersect(Geometry lhs, Geometry rhs, int limit)
 
     a.invert();
 
-    return {a.allPolygons(), error};
+    return Geometry{a.allPolygons(), error};
 }
 
 Node::Node(QList<Polygon> polygons, int limit)

--- a/qtcsg/qtcsg.h
+++ b/qtcsg/qtcsg.h
@@ -166,11 +166,10 @@ private:
 class Geometry
 {
 public:
-    Geometry() = default;
-    Geometry(QList<Polygon> polygons, Error error = Error::NoError)
+    explicit Geometry() = default;
+    explicit Geometry(QList<Polygon> polygons, Error error = Error::NoError)
         : m_polygons{std::move(polygons)}
-        , m_error{error}
-    {}
+        , m_error{error} {}
 
     [[nodiscard]] auto isEmpty() const { return m_polygons.isEmpty(); }
     [[nodiscard]] auto polygons() const { return m_polygons; }

--- a/qtcsg/qtcsg.h
+++ b/qtcsg/qtcsg.h
@@ -38,6 +38,9 @@ enum class Error
 {
     NoError,
     RecursionError,
+    NotSupportedError,
+    FileSystemError,
+    FileFormatError,
 };
 
 Q_ENUM_NS(Error)
@@ -166,7 +169,8 @@ private:
 class Geometry
 {
 public:
-    explicit Geometry() = default;
+    explicit Geometry(Error error = Error::NoError)
+        : m_error{error} {}
     explicit Geometry(QList<Polygon> polygons, Error error = Error::NoError)
         : m_polygons{std::move(polygons)}
         , m_error{error} {}
@@ -184,7 +188,7 @@ public:
 
 private:
     QList<Polygon> m_polygons;
-    Error m_error = Error::NoError;
+    Error m_error;
 };
 
 /// Holds a node in a BSP tree. A BSP tree is built from a collection of polygons

--- a/qtcsg/qtcsgio.cpp
+++ b/qtcsg/qtcsgio.cpp
@@ -1,0 +1,279 @@
+#include "qtcsgio.h"
+
+#include <QFile>
+#include <QFileInfo>
+#include <QLoggingCategory>
+#include <QTextStream>
+
+namespace QtCSG {
+
+namespace {
+
+Q_LOGGING_CATEGORY(lcInputOutput, "qtcsg.io");
+
+template<class T>
+concept HasEmplaceBack = requires(T *object) {
+    object->emplaceBack(typename T::value_type{});
+};
+
+template<class T, typename... Args>
+void emplaceBack(QList<T> &list, Args... args)
+{
+    static_assert(HasEmplaceBack<QList<T>>
+                  || QT_VERSION_MAJOR < 6);
+
+    if constexpr (HasEmplaceBack<QList<T>>) {
+        list.emplaceBack(std::forward<Args>(args)...);
+    } else {
+        list.append(T{std::forward<Args>(args)...});
+    }
+}
+
+// http://www.geomview.org/docs/html/OFF.html
+class OffFileFormat : public FileFormat<Geometry>
+{
+public:
+    QString id() const override { return "OFF"; }
+    bool accepts(QString fileName) const override;
+    Geometry readGeometry(QIODevice *device) const override;
+    Error writeGeometry(Geometry geometry, QIODevice *device) const override;
+};
+
+bool OffFileFormat::accepts(QString fileName) const
+{
+    return fileName.endsWith(".off", Qt::CaseInsensitive);
+}
+
+Geometry OffFileFormat::readGeometry(QIODevice *device) const
+{
+    enum class State {
+        Magic,
+        Header,
+        Vertices,
+        Faces,
+    };
+
+    auto state = State::Magic;
+    auto vertexCount = int{};
+    auto faceCount = int{};
+    auto ok = false;
+
+    auto stream = QTextStream{device};
+    auto vertices = std::vector<QVector3D>{};
+    auto polygons = QList<Polygon>{};
+
+    for (auto lineNumber = 1; !stream.atEnd(); ++lineNumber) {
+        const auto line = stream.readLine().trimmed();
+
+        if (line.startsWith('#'))
+            continue;
+
+        switch (state) {
+        case State::Magic:
+            if (line != "OFF") {
+                qCWarning(lcInputOutput, "Unsupported file format");
+                return Geometry{Error::NotSupportedError};
+            }
+
+            state = State::Header;
+            break;
+
+        case State::Header:
+            vertexCount = line.section(' ', 0, 0).toInt(&ok);
+
+            if (!ok) {
+                qCWarning(lcInputOutput, "Invalid vertex count at line %d", lineNumber);
+                return Geometry{Error::FileFormatError};
+            }
+
+            faceCount = line.section(' ', 1, 1).toInt(&ok);
+
+            if (!ok) {
+                qCWarning(lcInputOutput, "Invalid face count at line %d", lineNumber);
+                return Geometry{Error::FileFormatError};
+            }
+
+            vertices.reserve(vertexCount);
+            polygons.reserve(faceCount);
+            state = State::Vertices;
+            break;
+
+        case State::Vertices:
+            if (const auto x = line.section(' ', 0, 0).toFloat(&ok); ok) {
+                if (const auto y = line.section(' ', 1, 1).toFloat(&ok); ok) {
+                    if (const auto z = line.section(' ', 2, 2).toFloat(&ok); ok) {
+                        vertices.emplace_back(x, y, z);
+
+                        if (--vertexCount == 0)
+                            state = State::Faces;
+
+                        break;
+                    }
+                }
+            }
+
+            qCWarning(lcInputOutput, "Invalid vertex at line %d", lineNumber);
+            return Geometry{Error::FileFormatError};
+
+        case State::Faces:
+            if (const auto n = line.section(' ', 0, 0).toInt(&ok); ok) {
+                auto indices = QList<int>{};
+                indices.reserve(n);
+
+                for (auto i = 1; i <= n; ++i) {
+                    if (const auto index = line.section(' ', i, i).toInt(&ok);
+                        ok && index >= 0 && index < vertices.size()) {
+                        emplaceBack(indices, index);
+                    } else {
+                        qCWarning(lcInputOutput, "Invalid index at line %d, field %d", lineNumber, i);
+                        return Geometry{Error::FileFormatError};
+                    }
+                }
+
+                auto outline = QList<Vertex>{};
+                outline.reserve(indices.size());
+
+                for (auto j = 0; j < n; ++j) {
+                    const auto i = (j + n - 1) % n;
+                    const auto k = (j + 1) % n;
+
+                    auto a = vertices.at(indices.at(i));
+                    auto b = vertices.at(indices.at(j));
+                    auto c = vertices.at(indices.at(k));
+                    auto n = QVector3D::crossProduct(b - a, c - a);
+
+                    n.normalize();
+
+                    emplaceBack(outline, std::move(b), std::move(n));
+                }
+
+                emplaceBack(polygons, std::move(outline));
+
+                if (--faceCount == 0)
+                    return Geometry{std::move(polygons)};
+
+                continue;
+            }
+
+            qCWarning(lcInputOutput, "Invalid index count at line %d", lineNumber);
+            return Geometry{Error::FileFormatError};
+        }
+    }
+
+    qCWarning(lcInputOutput, "Unexpected end of file");
+    return Geometry{Error::FileFormatError};
+}
+
+Error OffFileFormat::writeGeometry(Geometry geometry, QIODevice *device) const
+{
+    auto faces = std::vector<std::vector<std::size_t>>{};
+    auto vertices = std::vector<QVector3D>{};
+
+    const auto polygons = geometry.polygons();
+    faces.reserve(polygons.size());
+
+    for (const auto &p: polygons) {
+        faces.emplace_back();
+        faces.back().reserve(p.vertices().count());
+
+        for (const auto &v: p.vertices()) {
+            const auto p = v.position();
+
+            auto it = std::find(vertices.begin(), vertices.end(), p);
+
+            if (it == vertices.end())
+                it = vertices.emplace(vertices.end(), p.x(), p.y(), p.z());
+
+            faces.back().emplace_back(it - vertices.begin());
+        }
+    }
+
+    auto stream = QTextStream{device};
+
+    stream << "OFF" << Qt::endl;
+    stream << vertices.size() << ' ' << faces.size() << " 0" << Qt::endl;
+
+    for (const auto &v: vertices)
+        stream << v.x() << ' '<< v.y() << ' '<< v.z() << Qt::endl;
+
+    for (const auto &f: faces) {
+        stream << f.size();
+
+        for (const auto i: f)
+            stream << ' ' << i;
+
+        stream << Qt::endl;
+    }
+
+    return Error::NoError;
+}
+
+Geometry readGeometry(const FileFormat<Geometry> *format, QString fileName)
+{
+    auto file = QFile{fileName};
+
+    if (file.open(QFile::ReadOnly))
+        return format->readGeometry(&file);
+
+    qCWarning(lcInputOutput, "%ls: %ls",
+              qUtf16Printable(file.fileName()),
+              qUtf16Printable(file.errorString()));
+
+    return Geometry{Error::FileSystemError};
+}
+
+Error writeGeometry(const FileFormat<Geometry> *format, Geometry geometry, QString fileName)
+{
+    auto file = QFile{fileName};
+
+    if (file.open(QFile::WriteOnly))
+        return format->writeGeometry(std::move(geometry), &file);
+
+    qCWarning(lcInputOutput, "%ls: %ls",
+              qUtf16Printable(file.fileName()),
+              qUtf16Printable(file.errorString()));
+
+    return Error::FileSystemError;
+}
+
+} // namespace
+
+template<>
+FileFormat<Geometry>::List FileFormat<Geometry>::supported()
+{
+    static const auto list = QList {
+        offFileFormat(),
+    };
+
+    return list;
+}
+
+const FileFormat<Geometry> *offFileFormat()
+{
+    static const auto format = OffFileFormat{};
+    return &format;
+}
+
+Geometry readGeometry(QString fileName)
+{
+    for (const auto &fileFormat: FileFormat<Geometry>::supported()) {
+        if (fileFormat->accepts(fileName))
+            return readGeometry(fileFormat, std::move(fileName));
+    }
+
+    qCWarning(lcInputOutput, "%ls: Unsupported file format", qUtf16Printable(fileName));
+    return Geometry{Error::NotSupportedError};
+}
+
+Error writeGeometry(Geometry geometry, QString fileName)
+{
+    for (const auto &fileFormat: FileFormat<Geometry>::supported()) {
+        if (fileFormat->accepts(fileName))
+            return writeGeometry(fileFormat, std::move(geometry), std::move(fileName));
+    }
+
+    qCWarning(lcInputOutput, "%ls: Unsupported file format", qUtf16Printable(fileName));
+    return Error::NotSupportedError;
+}
+
+} // namespace QtCSG

--- a/qtcsg/qtcsgio.h
+++ b/qtcsg/qtcsgio.h
@@ -1,0 +1,29 @@
+#ifndef QTCSGIO_H
+#define QTCSGIO_H
+
+#include "qtcsg.h"
+
+class QIODevice;
+
+namespace QtCSG {
+
+template<class T>
+struct FileFormat
+{
+    virtual QString id() const = 0;
+    virtual bool accepts(QString fileName) const = 0;
+    virtual T readGeometry(QIODevice *device) const = 0;
+    virtual Error writeGeometry(T geometry, QIODevice *device) const = 0;
+
+    using List = QList<const FileFormat *>;
+    static List supported();
+};
+
+Geometry readGeometry(QString fileName);
+Error writeGeometry(Geometry geometry, QString fileName);
+
+const FileFormat<Geometry> *offFileFormat();
+
+} // namespace QtCSG
+
+#endif // QTCSGIO_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,4 +8,5 @@ add_library(QtCSGTestSuite qtcsgtest.h)
 target_link_libraries(QtCSGTestSuite PUBLIC QtCSG Qt::Test)
 
 qtcsg_add_testsuite(QtCSGTest qtcsgtest.cpp)
+qtcsg_add_testsuite(QtCSGIOTest qtcsgiotest.cpp)
 qtcsg_add_testsuite(QtCSGMathTest qtcsgmathtest.cpp)

--- a/tests/qtcsgiotest.cpp
+++ b/tests/qtcsgiotest.cpp
@@ -1,0 +1,66 @@
+/* QtCSG provides Constructive Solid Geometry (CSG) for Qt
+ * Copyright Ⓒ 2023 Mathias Hasselmann
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#include "qtcsgtest.h"
+
+#include <qtcsg/qtcsgio.h>
+
+#include <QBuffer>
+
+Q_DECLARE_METATYPE(const QtCSG::FileFormat<QtCSG::Geometry> *)
+
+namespace QtCSG::Tests {
+
+class IOTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testRoundTrip_data()
+    {
+        QTest::addColumn<const FileFormat<Geometry> *>("format");
+
+        for (const auto format: FileFormat<Geometry>::supported())
+            QTest::addRow("%ls", qUtf16Printable(format->id())) << format;
+    }
+
+    void testRoundTrip()
+    {
+        QFETCH(const FileFormat<Geometry> *const, format);
+
+        auto buffer = QBuffer{};
+
+        const auto geometry = QtCSG::cube();
+        QVERIFY2(buffer.open(QFile::WriteOnly), qUtf8Printable(buffer.errorString()));
+        format->writeGeometry(geometry, &buffer);
+        buffer.close();
+
+        QVERIFY2(buffer.open(QFile::ReadOnly), qUtf8Printable(buffer.errorString()));
+        const auto readBack = format->readGeometry(&buffer);
+        buffer.close();
+
+        QCOMPARE(readBack.error(), Error::NoError);
+        QCOMPARE(readBack.polygons(), geometry.polygons());
+    }
+};
+
+} // namespace QtCSG::Tests
+
+QTEST_MAIN(QtCSG::Tests::IOTest)
+
+#include "qtcsgiotest.moc"


### PR DESCRIPTION
This is mainly for loading problematic meshes within automated tests.
For more complete file format support use a library like assimp, or your highlevel 3D API.