### PR TITLE
Check arguments for isValid(), instead of isNull()

### DIFF
--- a/qtcsg/qtcsg.cpp
+++ b/qtcsg/qtcsg.cpp
@@ -392,7 +392,7 @@ Geometry parseGeometry(QString expression)
 
                 auto argValue = parseArgument(primitive, argName, match, *argSpec);
 
-                if (argValue.isNull())
+                if (!argValue.isValid()) // NOTE: default construction values were null for Qt5
                     return Geometry{Error::FileFormatError};
 
                 arguments.insert(std::move(argName), std::move(argValue));


### PR DESCRIPTION
Qt5 had the bad habit of considering default constructed values, like `QVector3D{}`, aka. the very valid vector `(0, 0, 0)` to be null.

Closes #40