### PR TITLE
Repair building with Clang

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -64,8 +64,8 @@ jobs:
 
 
           - platform:   ubuntu-24.04
-            packages:   clang-16
             compiler:   clang-16
+            packages:   clang-16 libc++-16-dev libc++abi-16-dev
             cc_path:    /usr/bin/clang-16
             cxx_path:   /usr/bin/clang++-16
             ninja_path: $IQTA_TOOLS/Ninja/ninja
@@ -76,8 +76,8 @@ jobs:
             qt_modules: 'qt3d'
 
           - platform:   ubuntu-24.04
-            packages:   clang-20
             compiler:   clang-20
+            packages:   clang-20 libc++-20-dev libc++abi-20-dev
             cc_path:    /usr/bin/clang-20
             cxx_path:   /usr/bin/clang++-20
             ninja_path: $IQTA_TOOLS/Ninja/ninja

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,16 @@ add_compile_definitions(
 
 add_compile_options(
     $<$<COMPILE_LANGUAGE:CXX>:-Werror=missing-declarations>
+    $<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>
     -Wall -Wextra
     -Werror=sign-compare
     -Werror=switch
     -Werror=unused
     -Werror=type-limits
+)
+
+add_link_options(
+    $<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>
 )
 
 include(QtCSGDebug)


### PR DESCRIPTION
Use libc++ instead of libstdc++ for Clang as it's too much work to always find a matching set of GCC headers that are fully understood by Clang.