### PR TITLE
Make Clang Tidy lookup more robust

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.25)
 
 project(QtCSG VERSION 0.1 LANGUAGES CXX)
 enable_testing()

--- a/cmake/QtCSGStaticCodeChecks.cmake
+++ b/cmake/QtCSGStaticCodeChecks.cmake
@@ -1,33 +1,35 @@
+cmake_minimum_required(VERSION 3.25)
+
+# ======================================================================================================================
+
 option(QTCSG_ENABLE_STATIC_CHECKS "Enable static code checking" OFF)
 
 if (NOT QTCSG_ENABLE_STATIC_CHECKS)
     return()
 endif()
 
+include(QtCSGVersionNumbers)
+
 # ======================================================================================================================
 
-message(CHECK_START "Looking for Clang Tidy static code analyzer")
+function(_qtcsg_accept_clang_tidy result_var executable_path)
+    message(VERBOSE "Validating ${executable_path}...")
 
-find_program( # ----------------------------------------------------------------------------- find clang-tidy executable
-    CLANG_TIDY_EXECUTABLE clang-tidy
-    DOC "Path to clang's static code analyzer"
-    NAMES clang-tidy-20 clang-tidy-19 clang-tidy-18
-    PATHS /opt/llvm-20/bin /opt/llvm-19/bin /opt/llvm-18/bin /usr/local/bin /usr/bin
-)
-
-if (CLANG_TIDY_EXECUTABLE)
-    execute_process( # ---------------------------------------------------------------------- resolve clang-tidy version
-        COMMAND "${CLANG_TIDY_EXECUTABLE}" "--version"
-        OUTPUT_VARIABLE clang_tidy_version_output OUTPUT_STRIP_TRAILING_WHITESPACE
+    execute_process(
+        COMMAND "${executable_path}" "--version"
+        OUTPUT_VARIABLE _version_output OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 
-    string(REPLACE "\n" ";" clang_tidy_version_output "${clang_tidy_version_output}")
-    list(GET clang_tidy_version_output 0 CLANG_TIDY_VERSION)
+    string(REPLACE "\n" ";" _version_output "${_version_output}")
+    list(GET _version_output 0 _version_string)
+    qtcsg_parse_version(_version)
 
-    message(CHECK_PASS "${CLANG_TIDY_EXECUTABLE} (${CLANG_TIDY_VERSION})") # ---------------------------- report success
-else()
-    message(CHECK_FAIL "Not found")
-endif()
+    if (_version VERSION_EQUAL CLAZY_LLVM_VERSION)
+        set("${result_var}" TRUE PARENT_SCOPE)
+    else()
+        set("${result_var}" FALSE PARENT_SCOPE)
+    endif()
+endfunction()
 
 # ======================================================================================================================
 
@@ -37,6 +39,7 @@ find_program( # ----------------------------------------------------------------
     CLAZY_STANDALONE_EXECUTABLE clazy-standalone
     DOC "Path to the Clazy static code analyzer"
     PATHS /opt/clazy/bin /usr/local/bin /usr/bin
+    REQUIRED
 )
 
 if (CLAZY_STANDALONE_EXECUTABLE)
@@ -45,19 +48,17 @@ if (CLAZY_STANDALONE_EXECUTABLE)
         OUTPUT_VARIABLE clazy_version_output OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 
-    string(REPLACE "\n" ";" clazy_version_output "${clazy_version_output}") # ------------------- convert output to list
+    string(REPLACE "\n" ";" clazy_version_output "${clazy_version_output}")
 
-    set(CLAZY_VERSION "${clazy_version_output}") # ------------------------------------- extract clazy version from list
-    list(FILTER CLAZY_VERSION INCLUDE REGEX "^clazy")
+    set(CLAZY_VERSION_STRING "${clazy_version_output}") # --------------------------------- resolve actual clazy version
+    list(FILTER CLAZY_VERSION_STRING INCLUDE REGEX "^clazy")
+    qtcsg_parse_version(CLAZY_VERSION)
 
-    list(FILTER clazy_version_output EXCLUDE REGEX "^clazy") # -------------------------- extract LLVM version from list
-    list(GET clazy_version_output 0 CLAZY_LLVM_VERSION)
+    list(FILTER clazy_version_output EXCLUDE REGEX "^clazy") # ------------------------------------ resolve LLVM version
+    list(GET clazy_version_output 0 CLAZY_LLVM_VERSION_STRING)
+    qtcsg_parse_version(CLAZY_LLVM_VERSION)
 
-    if (NOT "${clang_tidy_version_output}" STREQUAL "${clazy_version_output}")
-        message(FATAL_ERROR "LLVM version of Clazy (${CLAZY_LLVM_VERSION}) doesn't match Clang Tidy")
-    endif()
-
-    message(CHECK_PASS "${CLAZY_STANDALONE_EXECUTABLE} (${CLAZY_VERSION}, ${CLAZY_LLVM_VERSION})") # ---- report success
+    message(CHECK_PASS "${CLAZY_STANDALONE_EXECUTABLE} (clazy ${CLAZY_VERSION}, LLVM ${CLAZY_LLVM_VERSION})")
 else()
     message(CHECK_FAIL "Not found")
 endif()
@@ -67,10 +68,11 @@ endif()
 
 message(CHECK_START "Looking for Clazy's Clang Tidy plugin")
 
-find_program( # ----------------------------------------------------------------------- find clazy plugin for clang-tidy
+find_library( # ----------------------------------------------------------------------- find clazy plugin for clang-tidy
     CLAZY_CLANG_TIDY_PLUGIN "ClazyClangTidy${CMAKE_SHARED_LIBRARY_SUFFIX}"
     DOC "Path to the Clazy's clang-tidy plugin"
     PATHS /opt/clazy/lib /usr/local/lib /usr/lib
+    REQUIRED
 )
 
 if (CLAZY_CLANG_TIDY_PLUGIN)
@@ -81,10 +83,46 @@ endif()
 
 # ======================================================================================================================
 
+message(CHECK_START "Looking for Clang Tidy static code analyzer")
+
+find_program( # ----------------------------------------------------------------------------- find clang-tidy executable
+    CLANG_TIDY_EXECUTABLE clang-tidy
+    DOC "Path to clang's static code analyzer"
+    NAMES clang-tidy-${CLAZY_LLVM_VERSION_MAJOR}
+    PATHS /opt/llvm/bin /opt/llvm-${CLAZY_LLVM_VERSION}/bin /usr/local/bin /usr/bin
+    VALIDATOR _qtcsg_accept_clang_tidy
+    REQUIRED
+)
+
+if (CLANG_TIDY_EXECUTABLE)
+    execute_process( # ---------------------------------------------------------------------- resolve clang-tidy version
+        COMMAND "${CLANG_TIDY_EXECUTABLE}" "--version"
+        OUTPUT_VARIABLE clang_tidy_version_output OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    string(REPLACE "\n" ";" clang_tidy_version_output "${clang_tidy_version_output}")
+    list(GET clang_tidy_version_output 0 CLANG_TIDY_VERSION_STRING)
+    qtcsg_parse_version(CLANG_TIDY_VERSION)
+
+    message(CHECK_PASS "${CLANG_TIDY_EXECUTABLE} (${CLANG_TIDY_VERSION})") # ---------------------------- report success
+else()
+    message(CHECK_FAIL "Not found")
+endif()
+
+# ======================================================================================================================
+
 if (NOT CLANG_TIDY_EXECUTABLE
         OR NOT CLAZY_STANDALONE_EXECUTABLE
         OR NOT CLAZY_CLANG_TIDY_PLUGIN)
     message(FATAL_ERROR "Static code checking enabled, but could not find all required tools")
+    return()
+endif()
+
+if (NOT CLANG_TIDY_VERSION VERSION_EQUAL CLAZY_LLVM_VERSION)
+    message(
+        FATAL_ERROR "Incorrect Clang Tidy version (${CLANG_TIDY_VERSION_STRING})"
+        " for use with the selected Clazy plugin (${CLAZY_LLVM_VERSION_STRING})"
+    )
     return()
 endif()
 
@@ -105,7 +143,7 @@ if (CLAZY_CHECKS MATCHES "level[0-9]+")
     list(TRANSFORM CLAZY_CHECKS STRIP)
 endif()
 
-message(STATUS "Selected Clazy checks: ${CLAZY_CHECKS}")
+message(VERBOSE "Selected Clazy checks: ${CLAZY_CHECKS}")
 list(TRANSFORM CLAZY_CHECKS PREPEND "clazy-")
 
 # ======================================================================================================================

--- a/cmake/QtCSGVersionNumbers.cmake
+++ b/cmake/QtCSGVersionNumbers.cmake
@@ -1,0 +1,86 @@
+# qtcsg_parse_version(<output_variable> [<version_string>])
+#
+# Extracts a normalized dotted version number from a string and populates
+# version components into well‑known variables.
+#
+# This function accepts an optional version string. If no argument is given,
+# it attempts to derive the version from:
+#
+#   <output_variable>_STRING
+#   <output_variable>
+#
+# in that order. The first non‑empty value is used as the source string.
+#
+# From the selected string, the function extracts the first occurrence of a
+# version‑like pattern of the form:
+#
+#     <digits>(.<digits>)*
+#
+# The match must be either at the beginning of the string or preceded by a
+# non‑digit character. If no valid version can be found, the function aborts
+# with a fatal error.
+#
+# On success, the following variables are set in the parent scope:
+#
+#   <output_variable>          — the normalized version string (e.g. "1.2.3")
+#   <output_variable>_MAJOR    — first numeric component
+#   <output_variable>_MINOR    — second component, if present
+#   <output_variable>_PATCH    — third component, if present
+#   <output_variable>_TWEAK    — fourth component, if present
+#
+# Versions with more than four components are truncated.
+#
+# Example:
+#
+#   qtcsg_parse_version(MYLIB_VERSION "v1.4.2-beta")
+#
+# This produces:
+#
+#   MYLIB_VERSION        = "1.4.2"
+#   MYLIB_VERSION_MAJOR  = "1"
+#   MYLIB_VERSION_MINOR  = "4"
+#   MYLIB_VERSION_PATCH  = "2"
+#
+function(qtcsg_parse_version output_variable)
+    # get version string from optional argument
+    if (NOT "${ARGN}" STREQUAL "")
+        set(_version_string "${ARGN}")
+    endif()
+
+    # find version string via output_variable if no argument was specified
+    if (NOT DEFINED _version_string OR _version_string STREQUAL "")
+        set(_version_string "${${output_variable}_STRING}")
+    endif()
+
+    if (NOT DEFINED _version_string OR _version_string STREQUAL "")
+        set(_version_string "${${output_variable}}")
+    endif()
+
+    # extract version number from version string
+    string(REGEX MATCH "(^|[^0-9])(([0-9]+\\.)*[0-9]+)" _version_found "${_version_string}")
+
+    if (_version_found STREQUAL "")
+        message(FATAL_ERROR "Version string argument required, or valid version number in ${output_variable}")
+    endif()
+
+    set(_version_number "${CMAKE_MATCH_2}")
+    set("${output_variable}" "${_version_number}" PARENT_SCOPE)
+
+    # extract known version components into common variables
+    string(REPLACE "." ";" _version_parts "${_version_number}")
+
+    set(_part_names MAJOR MINOR PATCH TWEAK)
+    list(LENGTH _version_parts _version_length)
+
+    if (_version_length GREATER 4)
+        set(_version_length 4)
+    endif()
+
+    math(EXPR _last_part "${_version_length} - 1")
+
+    foreach(_index RANGE "${_last_part}")
+        list(GET _version_parts "${_index}" _value)
+        list(GET _part_names "${_index}" _name)
+        set("${output_variable}_${_name}" "${_value}" PARENT_SCOPE)
+    endforeach()
+endfunction()


### PR DESCRIPTION
Search Clazy first and then only accept Clang Tidy versions, that match the selected Clazy version.